### PR TITLE
now zips the directory, not just the contents

### DIFF
--- a/android/src/main/kotlin/com/kineapps/flutterarchive/FlutterArchivePlugin.kt
+++ b/android/src/main/kotlin/com/kineapps/flutterarchive/FlutterArchivePlugin.kt
@@ -154,7 +154,7 @@ class FlutterArchivePlugin : FlutterPlugin, MethodCallHandler {
 
     @Throws(IOException::class)
     private fun zip(sourceDirPath: String, zipFilePath: String, recurseSubDirs: Boolean?) {
-        val rootDirectory = File(sourceDirPath)
+        val rootDirectory = File(sourceDirPath).getParentFile()
 
         Log.i("zip", "Root directory: $sourceDirPath")
         Log.i("zip", "Zip file path: $zipFilePath")

--- a/ios/Classes/SwiftFlutterArchivePlugin.swift
+++ b/ios/Classes/SwiftFlutterArchivePlugin.swift
@@ -61,7 +61,7 @@ public class SwiftFlutterArchivePlugin: NSObject, FlutterPlugin {
                 do {
                     try fileManager.zipItem(at: sourceURL,
                                             to: destinationURL,
-                                            shouldKeepParent: false,
+                                            shouldKeepParent: true,
                                             compressionMethod: .deflate)
                     DispatchQueue.main.async {
                         self.log("Created zip at: " + destinationURL.path)


### PR DESCRIPTION
I changed it to the 'expected' behavior.  I don't want to compress a directory, then decompress it and just get a bunch of files scattered everywhere, I want the original directory.  You could make this a parameter, but I didn't bother.