### PR TITLE
Lower min ios version to 9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+- Added support for iOS 9
+
 ## 2.0.0
 
 - Added support for macOS (thanks for the PR to [tonycn](https://github.com/tonycn))

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Create and extract ZIP archive files. Uses Android/iOS/macOS platform APIs for h
 
 ## Features
 
-- Supports Android (API level 16+), iOS 10+ and macOS 10.11+.
+- Supports Android (API level 16+), iOS 9+ and macOS 10.11+.
 - Modern plugin implementation based on Kotlin (Android) and Swift (iOS/macOS).
 - Uses background processing to keep UI responsive.
 - Zip all files in a directory (optionally recursively).

--- a/ios/flutter_archive.podspec
+++ b/ios/flutter_archive.podspec
@@ -17,7 +17,8 @@ A new flutter plugin project.
   s.dependency 'Flutter'
   s.dependency 'ZIPFoundation', '0.9.11'
 
-  s.ios.deployment_target = '10.0'
+  s.ios.deployment_target = '9.0'
+
   # https://github.com/flutter/flutter/issues/40289
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_archive
 description: Create and extract ZIP archive files in Android, iOS and macOS. Zip all files in a directory recursively or a given list of files.
-version: 2.0.0
+version: 2.0.1
 homepage: https://github.com/kineapps/flutter_archive
 repository: https://github.com/kineapps/flutter_archive
 


### PR DESCRIPTION
Current version isn't compatible with apps supports iOS 9. 

If ios/Podifle contains `platform :ios, '9.0'`, the app can't be compiled:
```
ios % pod install
Analyzing dependencies
[!] CocoaPods could not find compatible versions for pod "flutter_archive":
  In Podfile:
    flutter_archive (from `.symlinks/plugins/flutter_archive/ios`)

Specs satisfying the `flutter_archive (from `.symlinks/plugins/flutter_archive/ios`)` dependency were found, but they required a higher minimum deployment target.
```

However the plugin doesn't require iOS 10 so min version can be lowered