### PR TITLE
deps: update dependency ZIPFoundation to 0.9.13

### DIFF
--- a/ios/flutter_archive.podspec
+++ b/ios/flutter_archive.podspec
@@ -16,10 +16,10 @@ A new flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'ZIPFoundation', '0.9.11'
+  s.dependency 'ZIPFoundation', '0.9.13'
 
-  s.platform = :ios, '9.0'
-  s.ios.deployment_target = '9.0'
+  s.platform = :ios, '12.0'
+  s.ios.deployment_target = '12.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/macos/flutter_archive.podspec
+++ b/macos/flutter_archive.podspec
@@ -15,7 +15,7 @@ A new flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files     = 'Classes/**/*'
   s.dependency 'FlutterMacOS'
-  s.dependency 'ZIPFoundation', '0.9.11'
+  s.dependency 'ZIPFoundation', '0.9.13'
 
   s.platform = :osx, '10.11'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }


### PR DESCRIPTION
Update the ZIPFoundation dependency to version 0.9.13. The deployment target was bumped to 12.0.
The reason behind that update is to fix some unzipping issues on iOS with .msa files.