### PR TITLE
Flutter Beta Result Method Channel Fix

### DIFF
--- a/android/src/main/kotlin/com/kineapps/flutterarchive/FlutterArchivePlugin.kt
+++ b/android/src/main/kotlin/com/kineapps/flutterarchive/FlutterArchivePlugin.kt
@@ -469,7 +469,7 @@ class FlutterArchivePlugin : FlutterPlugin, MethodCallHandler {
                     }
                 }
 
-                override fun error(code: String?, msg: String?, details: Any?) {
+                override fun error(code: String, msg: String?, details: Any?) {
                     Log.e(LOG_TAG, "invokeMethod - error: $msg")
                     // ignore error and extract normally
                     deferred.complete(ZipFileOperation.INCLUDE_ITEM)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_archive
 description: Create and extract ZIP archive files in Android, iOS and macOS. Zip all files in a directory recursively or a given list of files.
-version: 4.2.0
+version: 4.2.0-enfold
 homepage: https://github.com/kineapps/flutter_archive
 repository: https://github.com/kineapps/flutter_archive
 


### PR DESCRIPTION
A minor change in the latest beta flutter version (2.12.0-4.2.pre) was preventing our app to be built when depending on flutter_archive. A change to the Results method channel's error function removed the nullability of the code parameter. This PR changes code to be non-nullable and allowed our app to build properly.  