### PR TITLE
Bump ZIPFoundation dependency to 0.9.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 6.0.1
+- [iOS] Upgraded to ZIPFoundation 0.9.18
+
 ## 6.0.0
 - [Andfroid] Fix AGP 8.0 compile error
 - [Andfroid] Updated gradle version 7.3.1 and Kotlin version 1.7.10

--- a/ios/flutter_archive.podspec
+++ b/ios/flutter_archive.podspec
@@ -16,7 +16,7 @@ A new flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'ZIPFoundation', '0.9.13'
+  s.dependency 'ZIPFoundation', '0.9.18'
 
   s.platform = :ios, '12.0'
   s.ios.deployment_target = '12.0'

--- a/macos/flutter_archive.podspec
+++ b/macos/flutter_archive.podspec
@@ -15,7 +15,7 @@ A new flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files     = 'Classes/**/*'
   s.dependency 'FlutterMacOS'
-  s.dependency 'ZIPFoundation', '0.9.13'
+  s.dependency 'ZIPFoundation', '0.9.18'
 
   s.platform = :osx, '10.11'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_archive
 description: Create and extract ZIP archive files in Android, iOS and macOS. Zip all files in a directory recursively or a given list of files.
-version: 6.0.0
+version: 6.0.1
 homepage: https://github.com/kineapps/flutter_archive
 repository: https://github.com/kineapps/flutter_archive
 


### PR DESCRIPTION
Addresses pen test warnings on the known vulnerabilities of ZIPFoundation 0.9.13