### PR TITLE
Fix "Could not find method kotlin()" on AGP 9 when built-in Kotlin is off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.3.1
+
+- [Android] Fix "Could not find method kotlin()" build failure on AGP 9 when built-in Kotlin is disabled (the Flutter template default) — only configure the kotlin {} DSL when the Kotlin Gradle Plugin is applied, and apply KGP when built-in Kotlin is off (#86)
+
 ## 6.3.0
 
 - [iOS] Raised declared deployment target to 13.0 to match the minimum already required by Flutter 3.44+

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,9 +24,15 @@ rootProject.allprojects {
 
 apply plugin: 'com.android.library'
 
-// AGP 9+ has built-in Kotlin support; older versions need the plugin explicitly.
+// AGP 9+ has built-in Kotlin support, but only when the consumer enables it
+// (android.builtInKotlin=true). Apply the Kotlin Gradle Plugin on older AGP, or
+// whenever built-in Kotlin is off, so the kotlin {} DSL always has a provider.
 def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
-if (agpMajor < 9) {
+def builtInKotlin = providers.gradleProperty("android.builtInKotlin")
+        .map { it.toBoolean() }
+        .orElse(agpMajor >= 9)
+        .get()
+if (agpMajor < 9 || !builtInKotlin) {
     apply plugin: 'kotlin-android'
 }
 
@@ -54,9 +60,13 @@ android {
     }
 }
 
-kotlin {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+// The kotlin {} DSL is only registered when the Kotlin Gradle Plugin is applied;
+// under built-in Kotlin (no KGP) it is absent, so guard the configuration.
+plugins.withId("org.jetbrains.kotlin.android") {
+    kotlin {
+        compilerOptions {
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+        }
     }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_archive
 description: Create and extract ZIP archive files in Android, iOS and macOS. Zip all files in a directory recursively or a given list of files.
-version: 6.3.0
+version: 6.3.1
 homepage: https://github.com/kineapps/flutter_archive
 repository: https://github.com/kineapps/flutter_archive
 


### PR DESCRIPTION
## Summary
- Fix the `Could not find method kotlin()` build failure on AGP 9 when `android.builtInKotlin=false` (the Flutter template default). On AGP 9 the Kotlin Gradle Plugin is skipped, so the unconditional `kotlin {}` block had no provider.
- Configure the `kotlin {}` DSL only when KGP is applied (`plugins.withId("org.jetbrains.kotlin.android")`), and apply `kotlin-android` whenever built-in Kotlin is off (`agpMajor < 9 || !builtInKotlin`).

## Test plan
- Reproduced the crash in a fresh Flutter 3.44 app (AGP 9.0.1, `builtInKotlin=false`); the fix builds cleanly.
- Verified `builtInKotlin=true` (AGP 9) and AGP 8.11.1 both still build.

Fixes #86